### PR TITLE
style: adjust styling for all allauth pages

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -212,6 +212,15 @@ label {
   color: var(--light-burgundy);
 }
 
+/* Allauth */
+.allauth-link {
+  color: var(--light-burgundy)!important;
+}
+
+.allauth-link:hover {
+  color: var(--dark-burgundy) !important;
+}
+
 @media (max-width: 768px) {
   .logo {
     width: 50px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -233,6 +233,10 @@ a[href*="password/reset"]:hover {
   text-decoration: underline;
 }
 
+li {
+  list-style-type: none !important;
+}
+
 @media (max-width: 768px) {
   .logo {
     width: 50px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -221,6 +221,18 @@ label {
   color: var(--dark-burgundy) !important;
 }
 
+a[href*="password/reset"] {
+  color: var(--light-burgundy);
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.3s ease-in-out;
+}
+
+a[href*="password/reset"]:hover {
+  color: var(--dark-burgundy);
+  text-decoration: underline;
+}
+
 @media (max-width: 768px) {
   .logo {
     width: 50px;

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,57 +1,58 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load crispy_forms_tags %}
+{% load static %}
+
 {% load allauth account %}
 {% block head_title %}
-    {% trans "Sign In" %}
+    {% trans "Log In" %}
 {% endblock head_title %}
 {% block content %}
-    {% element h1 %}
-        {% trans "Sign In" %}
-    {% endelement %}
-    {% if not SOCIALACCOUNT_ONLY %}
-        {% setvar link %}
-            <a href="{{ signup_url }}">
-            {% endsetvar %}
-            {% setvar end_link %}
-            </a>
-        {% endsetvar %}
-        {% element p %}
-            {% blocktranslate %}If you have not created an account yet, then please {{ link }}sign up{{ end_link }} first.{% endblocktranslate %}
-        {% endelement %}
-        {% url 'account_login' as login_url %}
-        {% element form form=form method="post" action=login_url tags="entrance,login" %}
-            {% slot body %}
-                {% csrf_token %}
-                {% element fields form=form unlabeled=True %}
-                {% endelement %}
-                {{ redirect_field }}
-            {% endslot %}
-            {% slot actions %}
-                {% element button type="submit" tags="prominent,login" %}
-                    {% trans "Sign In" %}
-                {% endelement %}
-            {% endslot %}
-        {% endelement %}
-    {% endif %}
-    {% if LOGIN_BY_CODE_ENABLED or PASSKEY_LOGIN_ENABLED %}
-        {% element hr %}
-        {% endelement %}
-        {% element button_group vertical=True %}
-            {% if PASSKEY_LOGIN_ENABLED %}
-                {% element button type="submit" form="mfa_login" id="passkey_login" tags="prominent,login,outline,primary" %}
-                    {% trans "Sign in with a passkey" %}
-                {% endelement %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-12 col-lg-10 col-xl-8 text-center mx-auto">
+            <header class="mt-4">
+                <h1>{% trans "Log In" %}</h1>
+            </header>
+            {% if not SOCIALACCOUNT_ONLY %}
+                {% setvar link %}
+                    <a href="{{ signup_url }}">
+                    {% endsetvar %}
+                    {% setvar end_link %}
+                    </a>
+                {% endsetvar %}
+                <p class="mt-3">
+                    {% blocktranslate %}If you have not created an account yet, then please <a href="{{ signup_url }}" class="allauth-link text-decoration-none fw-semibold">create profile</a> first.{% endblocktranslate %}
+                </p>
+                {% url 'account_login' as login_url %}
+                <form method="post" action="{% url 'account_login' %}" class="shadow p-3 border rounded">
+                            {% csrf_token %}
+                            {{ form|crispy }}
+                            {{ redirect_field }}
+                            <button type="submit" class="btn btn-pink mt-3" aria-label="Sign in button">
+                                {% trans "Log In" %}
+                            </button>
+                        </form>
             {% endif %}
-            {% if LOGIN_BY_CODE_ENABLED %}
-                {% element button href=request_login_code_url tags="prominent,login,outline,primary" %}
-                    {% trans "Mail me a sign-in code" %}
-                {% endelement %}
+            {% if LOGIN_BY_CODE_ENABLED or PASSKEY_LOGIN_ENABLED %}
+                <hr class="mt-4">
+                    {% if PASSKEY_LOGIN_ENABLED %}
+                        <button type="submit" form="mfa_login" id="passkey_login" class="btn btn-pink">
+                            {% trans "Log in with a passkey" %}
+                        </button>
+                    {% endif %}
+                    {% if LOGIN_BY_CODE_ENABLED %}
+                        <a href="{{ request_login_code_url }}" class="btn btn-pink">
+                            {% trans "Mail me a sign-in code" %}
+                        </a>
+                    {% endif %}
             {% endif %}
-        {% endelement %}
-    {% endif %}
-    {% if SOCIALACCOUNT_ENABLED %}
-        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
-    {% endif %}
+            {% if SOCIALACCOUNT_ENABLED %}
+                {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock content %}
 {% block extra_body %}
     {{ block.super }}

--- a/templates/account/logout.html
+++ b/templates/account/logout.html
@@ -1,25 +1,30 @@
 {% extends "base.html" %}
 {% load allauth i18n %}
+{% load crispy_forms_tags %}
+{% load static %}
 {% block head_title %}
     {% trans "Sign Out" %}
 {% endblock head_title %}
 {% block content %}
-    {% element h1 %}
-        {% trans "Sign Out" %}
-    {% endelement %}
-    {% element p %}
-        {% trans 'Are you sure you want to sign out?' %}
-    {% endelement %}
-    {% url 'account_logout' as action_url %}
-    {% element form method="post" action=action_url no_visible_fields=True %}
-        {% slot body %}
-            {% csrf_token %}
-            {{ redirect_field }}
-        {% endslot %}
-        {% slot actions %}
-            {% element button type="submit" %}
-                {% trans 'Sign Out' %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-10 col-lg-6 col-xl-4 text-center mx-auto">
+            <header class="mt-4">
+                <h1>{% trans "Sign Out" %}</h1>
+            </header>
+            {% element p %}
+                {% trans 'Are you sure you want to sign out?' %}
             {% endelement %}
-        {% endslot %}
-    {% endelement %}
+            {% url 'account_logout' as action_url %}
+            <form method="post" action="{{ action_url }}" class="shadow p-3 border rounded">
+                {% csrf_token %}
+                {{ form|crispy }}
+                {{ redirect_field }}
+                <button type="submit" class="btn btn-pink mt-3" aria-label="Sign out button">
+                    {% trans 'Sign Out' %}
+                </button>
+            </form>
+        </div>
+    </div>
+</div>
 {% endblock content %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,45 +1,45 @@
 {% extends "base.html" %}
 {% load allauth i18n %}
+{% load crispy_forms_tags %}
+{% load static %}
+
 {% block head_title %}
     {% trans "Signup" %}
 {% endblock head_title %}
 {% block content %}
-    {% element h1 %}
-        {% trans "Sign Up" %}
-    {% endelement %}
-    {% setvar link %}
-        <a href="{{ login_url }}">
-        {% endsetvar %}
-        {% setvar end_link %}
-        </a>
-    {% endsetvar %}
-    {% element p %}
-        {% blocktranslate %}Already have an account? Then please {{ link }}sign in{{ end_link }}.{% endblocktranslate %}
-    {% endelement %}
-    {% if not SOCIALACCOUNT_ONLY %}
-        {% url 'account_signup' as action_url %}
-        {% element form form=form method="post" action=action_url tags="entrance,signup" %}
-            {% slot body %}
-                {% csrf_token %}
-                {% element fields form=form unlabeled=True %}
-                {% endelement %}
-                {{ redirect_field }}
-            {% endslot %}
-            {% slot actions %}
-                {% element button tags="prominent,signup" type="submit" %}
-                    {% trans "Sign Up" %}
-                {% endelement %}
-            {% endslot %}
-        {% endelement %}
-    {% endif %}
-    {% if PASSKEY_SIGNUP_ENABLED %}
-        {% element hr %}
-        {% endelement %}
-        {% element button href=signup_by_passkey_url tags="prominent,signup,outline,primary" %}
-            {% trans "Sign up using a passkey" %}
-        {% endelement %}
-    {% endif %}
-    {% if SOCIALACCOUNT_ENABLED %}
-        {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
-    {% endif %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-12 col-lg-10 col-xl-8 text-center pb-4 mx-auto">
+            <header class="mt-4">
+                <h1>{% trans "Create Profile" %}</h1>
+            </header>
+            <p class="mt-3">
+                {% blocktranslate %}Already have an account? Then please <a href="{{ login_url }}" class="allauth-link text-decoration-none fw-semibold">log in</a>.{% endblocktranslate %}
+            </p>
+            
+            {% if not SOCIALACCOUNT_ONLY %}
+                {% url 'account_signup' as action_url %}
+                <form method="post" action="{{ action_url }}" class="shadow p-3 border rounded">
+                    {% csrf_token %}
+                    {{ form|crispy }}
+                    {{ redirect_field }}
+                    <button type="submit" class="btn btn-pink mt-3" aria-label="Sign up button">
+                        {% trans "Sign Up" %}
+                    </button>
+                </form>
+            {% endif %}
+
+            {% if PASSKEY_SIGNUP_ENABLED %}
+                <hr class="mt-4">
+                <a href="{{ signup_by_passkey_url }}" class="btn btn-outline-primary mt-2">
+                    {% trans "Sign up using a passkey" %}
+                </a>
+            {% endif %}
+
+            {% if SOCIALACCOUNT_ENABLED %}
+                {% include "socialaccount/snippets/login.html" with page_layout="entrance" %}
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This pull request includes several changes aimed at improving the user interface and styling of the login, logout, and signup pages. The changes involve adding new CSS classes, updating HTML templates, and incorporating the `crispy_forms` library for better form rendering.

### CSS and Styling Changes:
* Added new CSS classes for `allauth-link` and updated styles for password reset links and list items in `static/css/style.css`.

### Template Updates:
* Updated `templates/account/login.html` to include `crispy_forms` and `static` libraries, and restructured the login form with new classes and styles.
* Updated `templates/account/logout.html` to include `crispy_forms` and `static` libraries, and restructured the logout form with new classes and styles.
* Updated `templates/account/signup.html` to include `crispy_forms` and `static` libraries, and restructured the signup form with new classes and styles.