### PR TITLE
style: adjust styling for password reset and email conf page

### DIFF
--- a/templates/account/email_confirm.html
+++ b/templates/account/email_confirm.html
@@ -1,39 +1,47 @@
-{% extends "account/base_entrance.html" %}
-{% load i18n %}
-{% load account %}
-{% load allauth %}
+{% extends "base.html" %}
+{% load i18n allauth %}
+{% load crispy_forms_tags %}
+{% load static %}
 {% block head_title %}
     {% trans "Confirm Email Address" %}
 {% endblock head_title %}
 {% block content %}
-    {% element h1 %}
-        {% trans "Confirm Email Address" %}
-    {% endelement %}
-    {% if confirmation %}
-        {% user_display confirmation.email_address.user as user_display %}
-        {% if can_confirm %}
-            {% element p %}
-                {% blocktrans with confirmation.email_address.email as email %}Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.{% endblocktrans %}
-            {% endelement %}
-            {% url 'account_confirm_email' confirmation.key as action_url %}
-            {% element form method="post" action=action_url %}
-                {% slot actions %}
-                    {% csrf_token %}
-                    {{ redirect_field }}
-                    {% element button type="submit" %}
-                        {% trans 'Confirm' %}
-                    {% endelement %}
-                {% endslot %}
-            {% endelement %}
-        {% else %}
-            {% element p %}
-                {% blocktrans %}Unable to confirm {{ email }} because it is already confirmed by a different account.{% endblocktrans %}
-            {% endelement %}
-        {% endif %}
-    {% else %}
-        {% url 'account_email' as email_url %}
-        {% element p %}
-            {% blocktrans %}This email confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new email confirmation request</a>.{% endblocktrans %}
-        {% endelement %}
-    {% endif %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-12 col-lg-10 col-xl-8 text-center mx-auto">
+            <header class="mt-4">
+                <h1>{% trans "Confirm Email Address" %}</h1>
+            </header>
+            {% if confirmation %}
+                {% user_display confirmation.email_address.user as user_display %}
+                {% if can_confirm %}
+                    <p class="mt-3">
+                        {% blocktrans with confirmation.email_address.email as email %}
+                            Please confirm that <a href="mailto:{{ email }}">{{ email }}</a> is an email address for user {{ user_display }}.
+                        {% endblocktrans %}
+                    </p>
+                    {% url 'account_confirm_email' confirmation.key as action_url %}
+                    <form method="post" action="{{ action_url }}" class="shadow p-3 border rounded">
+                        {% csrf_token %}
+                        {{ redirect_field }}
+                        {{ form|crispy }}
+                        <button type="submit" class="btn btn-pink mt-3" aria-label="Confirm email address">
+                            {% trans 'Confirm' %}
+                        </button>
+                    </form>
+
+                {% else %}
+                    <p class="mt-3">
+                        {% blocktrans %}Unable to confirm {{ email }} because it is already confirmed by a different account.{% endblocktrans %}
+                    </p>
+                {% endif %}
+            {% else %}
+                {% url 'account_email' as email_url %}
+                <p class="mt-3">
+                    {% blocktrans %}This email confirmation link expired or is invalid. Please <a href="{{ email_url }}">issue a new email confirmation request</a>.{% endblocktrans %}
+                </p>
+            {% endif %}
+        </div>
+    </div>
+</div>
 {% endblock content %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,32 +1,35 @@
-{% extends "account/base_entrance.html" %}
+{% extends "base.html" %}
 {% load i18n allauth account %}
+{% load crispy_forms_tags %}
+{% load static %}
 {% block head_title %}
     {% trans "Password Reset" %}
 {% endblock head_title %}
 {% block content %}
-    {% element h1 %}
-        {% trans "Password Reset" %}
-    {% endelement %}
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    {% element p %}
-        {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
-    {% endelement %}
-    {% url 'account_reset_password' as reset_url %}
-    {% element form form=form method="post" action=reset_url %}
-        {% slot body %}
-            {% csrf_token %}
-            {% element fields form=form %}
-            {% endelement %}
-        {% endslot %}
-        {% slot actions %}
-            {% element button type="submit" %}
-                {% trans 'Reset My Password' %}
-            {% endelement %}
-        {% endslot %}
-    {% endelement %}
-    {% element p %}
-        {% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}
-    {% endelement %}
+<div class="container">
+    <div class="row">
+        <div class="col-md-8 col-lg-6 col-xl-4 text-center mx-auto">
+            <header class="mt-4">
+                <h1>{% trans "Password Reset" %}</h1>
+            </header>
+            {% if user.is_authenticated %}
+                {% include "account/snippets/already_logged_in.html" %}
+            {% endif %}
+            <p class="mt-3">
+                {% trans "Forgotten your password? Enter your email address below, and we'll send you an email allowing you to reset it." %}
+            </p>
+            {% url 'account_reset_password' as reset_url %}
+            <form method="post" action="{{ reset_url }}" class="shadow p-3 border rounded">
+                {% csrf_token %}
+                {{ form|crispy }}
+                <button type="submit" class="btn btn-pink mt-3" aria-label="Reset password button">
+                    {% trans 'Reset My Password' %}
+                </button>
+            </form>
+            <p class="mt-3">
+                {% blocktrans %}Please contact us if you have any trouble resetting your password.{% endblocktrans %}
+            </p>
+        </div>
+    </div>
+</div>
 {% endblock content %}


### PR DESCRIPTION
This pull request includes changes to the email confirmation and password reset templates to enhance their styling and structure. The most important changes include updating the base template, adding new template tags, and modifying the HTML structure to use Bootstrap classes for better responsiveness and styling.

Template updates:

* Changed the base template from `account/base_entrance.html` to `base.html`, added `crispy_forms_tags` and `static` template tags, and updated the HTML structure to use Bootstrap classes for better styling and responsiveness.
* Changed the base template from `account/base_entrance.html` to `base.html`, added `crispy_forms_tags` and `static` template tags, and updated the HTML structure to use Bootstrap classes for better styling and responsiveness.