### PR TITLE
style: adjust btn classes for user messages

### DIFF
--- a/user_messages/templates/user_messages/conversation.html
+++ b/user_messages/templates/user_messages/conversation.html
@@ -23,12 +23,12 @@
         {% csrf_token %}
         <div class="input-group">
             <input type="text" class="form-control" name="content" placeholder="Type your message..." required>
-            <button type="submit" class="btn btn-primary">Send</button>
+            <button type="submit" class="btn btn-pink">Send</button>
         </div>
     </form>
 
     <div class="text-center mt-3">
-        <a href="{% url 'messages:inbox' %}" class="btn btn-secondary">Back to Inbox</a>
+        <a href="{% url 'messages:inbox' %}" class="btn btn-pink">Back to Inbox</a>
     </div>
 </div>
 {% endblock %}

--- a/user_messages/templates/user_messages/inbox.html
+++ b/user_messages/templates/user_messages/inbox.html
@@ -23,7 +23,7 @@
     </div>
 
     <div class="text-center mt-3">
-        <a href="{% url 'messages:message_requests' %}" class="btn btn-secondary">View Message Requests</a>
+        <a href="{% url 'messages:message_requests' %}" class="btn btn-pink">View Message Requests</a>
     </div>
 </div>
 {% endblock %}

--- a/user_messages/templates/user_messages/message_requests.html
+++ b/user_messages/templates/user_messages/message_requests.html
@@ -11,9 +11,9 @@
                         <span>{{ request.sender.username }} wants to chat</span>
                         <div>
                             <a href="{% url 'messages:respond_message_request' request.id 'accept' %}" 
-                               class="btn btn-success btn-sm">Accept</a>
+                               class="btn btn-pink btn-sm">Accept</a>
                             <a href="{% url 'messages:respond_message_request' request.id 'decline' %}" 
-                               class="btn btn-danger btn-sm">Decline</a>
+                               class="btn btn-red btn-sm">Decline</a>
                         </div>
                     </li>
                 {% endfor %}
@@ -24,7 +24,7 @@
     </div>
 
     <div class="text-center mt-3">
-        <a href="{% url 'messages:inbox' %}" class="btn btn-secondary">Back to Inbox</a>
+        <a href="{% url 'messages:inbox' %}" class="btn btn-pink">Back to Inbox</a>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This pull request includes changes to the button styles in several templates within the `user_messages` module. The primary change is updating the button classes to use consistent styling across different pages.

Button style updates:

* Changed the "Send" button and "Back to Inbox" button to use `btn-pink` class instead of `btn-primary` and `btn-secondary`, respectively.
* Updated the "View Message Requests" button to use `btn-pink` class instead of `btn-secondary`.
* Modified the "Accept" button to use `btn-pink` class instead of `btn-success` and the "Decline" button to use `btn-red` class instead of `btn-danger`. Additionally, changed the "Back to Inbox" button to use `btn-pink` class instead of `btn-secondary`.