### PR TITLE
fix: change Sparky Chat to Chat

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -75,7 +75,7 @@
                     </li>
                     <li class="nav-item px-2">
                         <a class="nav-link {% if request.path == '/chat/' %}active{% endif %}"
-                            href="{% url 'chat' %}">Sparky Chat</a>
+                            href="{% url 'chat' %}">Chat</a>
                     </li>
                     <li class="nav-item px-2">
                         <a class="nav-link {% if request.path == 'messages/inbox/' %}active{% endif %}"


### PR DESCRIPTION
This pull request includes a small change to the `templates/base.html` file. The change updates the navigation link text for the chat feature from "Sparky Chat" to "Chat".

* Updated the navigation link text from "Sparky Chat" to "Chat".