### PR TITLE
style: adjust notifications styling slightly and margin for footer btns

### DIFF
--- a/notificationapp/templates/notificationapp/notifications.html
+++ b/notificationapp/templates/notificationapp/notifications.html
@@ -2,17 +2,21 @@
 
 {% block content %}
     <div class="container mt-4 text-center">
-        <h2 class="mb-4">Notifications</h2>
-        <ul class="list-group mb-5"> <!-- Added mb-5 for extra space -->
-            {% for notification in notifications %}
-                <li class="list-group-item text-center">
-                    {{ notification.message }} <br>
-                    <small class="text-muted">{{ notification.created_at }}</small>
-                </li>
-            {% empty %}
-                <li class="list-group-item text-center text-muted">No new notifications</li>
-            {% endfor %}
-        </ul>
+        <h1 class="py-4">Notifications</h1>
+        <div class="row">
+            <div class="col-md-10 col-lg-8 mx-auto">
+                <ul class="list-group shadow mb-5"> <!-- Added mb-5 for extra space -->
+                    {% for notification in notifications %}
+                        <li class="list-group-item text-center">
+                            {{ notification.message }} <br>
+                            <small class="text-muted">{{ notification.created_at }}</small>
+                        </li>
+                    {% empty %}
+                        <li class="list-group-item text-center text-muted">No new notifications</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
     </div>
 {% endblock %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -133,11 +133,11 @@
             <span class="copyright fs-4 mb-1">&copy; SparkSync</span>
             <p class="pb-2">All rights reserved</p>
             <div class="d-flex flex-column flex-md-row align-items-center justify-content-center">
-                <a class="btn btn-pink rounded mt-3 mx-2 fs-6 text-decoration-none" href="{% url 'contact' %}"
+                <a class="btn btn-pink rounded mt-3 mx-3 fs-6 text-decoration-none" href="{% url 'contact' %}"
                     aria-label="Brings to Contact Page">Contact Us</a>
                 <a class="btn btn-pink rounded mt-3 fs-6 text-decoration-none" href="{% url 'faq' %}"
                     aria-label="Brings to FAQ Page">FAQ</a>
-                <a class="btn btn-pink rounded mt-3 mx-2 fs-6 text-decoration-none" href="{% url 'team' %}"
+                <a class="btn btn-pink rounded mt-3 mx-3 fs-6 text-decoration-none" href="{% url 'team' %}"
                     aria-label="Brings to Team Page">Meet the Team</a>
                 <a class="btn btn-pink rounded mt-3 fs-6 text-decoration-none" href="{% url 'policy' %}"
                     aria-label="Brings to Privacy Policy Page">Privacy Policy</a>


### PR DESCRIPTION
This pull request includes changes to the `notificationapp` and `templates` directories to improve the layout and styling of the notifications and footer sections. The most important changes include updating the notifications page layout and adjusting spacing in the footer buttons.

Improvements to notifications layout:

* Changed the heading from `h2` to `h1` with additional padding and restructured the layout to include a centered column with shadow effect for better aesthetics.
Styling adjustments in footer:

* Adjusted the horizontal margin (`mx-2` to `mx-3`) for the contact, FAQ, and team buttons to improve spacing consistency.