### PR TITLE
fix: add target=blank to social links on team page

### DIFF
--- a/home/templates/home/team.html
+++ b/home/templates/home/team.html
@@ -19,9 +19,9 @@
             <p class="card-text">As the SCRUM lead, Viola kept our team on track with a Kanban board (because chaos isn’t a strategy). She also jumped into development, wrangling Git workflows, designing the UI, and bringing the Team, FAQ, Privacy Policy, and Contact pages to life.</p>
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">"That's tomorrow's problem! "</span></p>
             <div class="mt-auto d-flex justify-content-center gap-3">
-              <a href="https://www.linkedin.com/in/viola-bergere/" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://www.linkedin.com/in/viola-bergere/" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Viola Bergere' LinkedIn profile">LinkedIn<i class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://github.com/violaberg" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/violaberg" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Viola Bergere' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>
@@ -40,9 +40,9 @@
             <p class="card-text">Agnieszka helped to brainstorm name for our app and craft its slogan to capture its essence. Beyond branding, she also developed the like button for the Sparks page, ensuring smooth functionality and an engaging user experience.</p>
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">" It's definitely a maybe! "</span></p>
             <div class="mt-auto d-flex justify-content-center gap-3">
-              <a href="https://www.linkedin.com/in/agnieszka21/" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://www.linkedin.com/in/agnieszka21/" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Agnieszka Bialek' LinkedIn profile">LinkedIn<i class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://github.com/Agnieszka-21" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/Agnieszka-21" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Agnieszka Bialek' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>
@@ -61,10 +61,10 @@
             <p class="card-text">Tamanna set up the initial navigation bar and integrated allauth for authentication. She also added notifications to keep users updated, gave some text a glowing effect for extra flair, and tested the code to make sure everything ran smoothly. Additionally, she implemented the "Report Profile" button and functionality to allow users to report profiles if needed.</p>
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">" Go ahead, Make my day! "</span></p>
             <div class="mt-auto d-flex justify-content-center gap-3">
-              <a href="#" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://www.linkedin.com/in/farha-tamanna-islam-sw-developer/" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Tamanna Islam' LinkedIn profile">LinkedIn<i
                   class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://www.linkedin.com/in/farha-tamanna-islam-sw-developer/" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/farhatamannaislam" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Tamanna Islam' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>
@@ -83,9 +83,9 @@
             <p class="card-text">Evangelos built the messaging system to keep conversations flowing and added a report button for flagging inappropriate messages. He also contributed to the app’s first impression by writing content for the home page and developing the profile system.</p>
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">" More Espresso, Less Deppresso! "</span></p>
             <div class="mt-top d-flex justify-content-center gap-3">
-              <a href="https://www.linkedin.com/in/evangelos-alexiou-b88759132/" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://www.linkedin.com/in/evangelos-alexiou-b88759132/" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Evangelos Alexiou' LinkedIn profile">LinkedIn<i class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://github.com/Alexiou981" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/Alexiou981" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Evangelos Alexiou' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>
@@ -104,10 +104,10 @@
             <p class="card-text">Jaime took the lead on designing our wireframes, mapping out the user experience and making sure everything looked and worked just right. He also built the real-time chat app from the ground up, making sure it had all the functionality to keep conversations flowing smoothly and seamlessly.</p>
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">"It's bad luck to be superstitious! "</span></p>
             <div class="mt-auto d-flex justify-content-center gap-3">
-              <a href="https://www.linkedin.com/in/language-landscapes/" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://www.linkedin.com/in/language-landscapes/" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Jaime Hyland' LinkedIn profile">LinkedIn<i
                   class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://github.com/JaimeHyland" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/JaimeHyland" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Jaime Hyland' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>
@@ -127,9 +127,9 @@
             <p class="team-p pt-2">Favourite Phrase: <br><span class="phrase fs-3">" Google it! "</span></p>
             <div class="mt-auto d-flex justify-content-center gap-3">
               <a href="https://www.linkedin.com/in/jan-rafanan/"
-                class="btn btn-pink p-2 text-decoration-none" aria-label="Visit Jan Rafanan' LinkedIn profile">LinkedIn<i
+                class="btn btn-pink p-2 text-decoration-none" target="_blank" aria-label="Visit Jan Rafanan' LinkedIn profile">LinkedIn<i
                   class="fs-5 fab fa-linkedin px-1"></i></a>
-              <a href="https://github.com/yanidruffy" class="btn btn-pink p-2 text-decoration-none"
+              <a href="https://github.com/yanidruffy" target="_blank" class="btn btn-pink p-2 text-decoration-none"
                 aria-label="Visit Jan Rafanan' Github profile">Github<i class="fs-5 fab fa-github px-1"></i></a>
             </div>
           </div>

--- a/profiles/templates/profiles/matching_profiles.html
+++ b/profiles/templates/profiles/matching_profiles.html
@@ -76,7 +76,7 @@
                     </div>
                 </div>
                 {% empty %}
-                <div class="row text-center mt-4 mb-3">
+                <div class="row text-center mx-auto mt-4 mb-3">
                     <p>No matching profiles found. Try adjusting your preferences in the questionnaire.</p>
                 </div>
                 {% endfor %}


### PR DESCRIPTION
This pull request includes multiple changes to the `home/templates/home/team.html` file to open links in new tabs and a minor layout adjustment in the `profiles/templates/profiles/matching_profiles.html` file. The most important changes are:

Changes to open links in new tabs:

* Updated LinkedIn and GitHub profile links for Viola Bergere to open in new tabs.
* Updated LinkedIn and GitHub profile links for Agnieszka Bialek to open in new tabs.
* Updated LinkedIn and GitHub profile links for Tamanna Islam to open in new tabs.
* Updated LinkedIn and GitHub profile links for Evangelos Alexiou to open in new tabs.
* Updated LinkedIn and GitHub profile links for Jaime Hyland to open in new tabs.
* Updated LinkedIn and GitHub profile links for Jan Rafanan to open in new tabs.
Layout adjustment:

* Adjusted the alignment of the "No matching profiles found" message to be centered on the page.