### PR TITLE
Jaime dev

### DIFF
--- a/chat/consumers.py
+++ b/chat/consumers.py
@@ -1,6 +1,5 @@
 
 import json
-
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 
@@ -23,9 +22,13 @@ class ChatConsumer(AsyncWebsocketConsumer):
         text_data_json = json.loads(text_data)
         message = text_data_json["message"]
 
+        username = text_data_json.get('username', 'Anonymous')
+
+        formatted_message = f"{username}: {message}"
+
         # Send message to room group
         await self.channel_layer.group_send(
-            self.room_group_name, {"type": "chat.message", "message": message}
+            self.room_group_name, {"type": "chat.message", "message": formatted_message}
         )
 
     # Receive message from roomASGI_APPLICATION = 'your_project_name.asgi.application' group

--- a/chat/templates/chat/chat.html
+++ b/chat/templates/chat/chat.html
@@ -3,7 +3,8 @@
 
 {% block content %}
 <div class="container py-4">
-    <div class="row">
+    <div class="row text-center py-2"">
+        {% if user.is_authenticated %}
         <div class="col-md-10 col-lg-8 mx-auto">
             <h1 class="text-center">What chat room would you like to enter?</h1>
             <select id="room-name-input" name="room_name" class="py-2 w-100 rounded shadow">
@@ -15,6 +16,16 @@
                 {% endfor %}
             </select>
         </div>
+        {% else %}
+        <div id="not_allowed" class="col-md-10 col-sm-12 col-xl-10 mx-auto"></div>
+            <h1 class="text-center pt-2">Oops! Page Not Found.</h1>
+            <p class="text-center px-3">You must be logged in to access the chat service!</p>
+            <a href="{% url 'home' %}" class="btn btn-pink rounded mt-3 p-2"
+                aria-label="Brings you back to Home Page">Back to Home
+                page
+            </a>
+        </div>
+        {% endif %}
     </div>
 </div>
 

--- a/chat/templates/chat/chatroom.html
+++ b/chat/templates/chat/chatroom.html
@@ -3,7 +3,9 @@
 
 {% block content %}
 <div class="container py-4">
+    {% if user.is_authenticated %}
     <div class="row">
+        <span id="user-username" style="display:none;">"{{ user.username }}"</span>
         <div class="col-md-10 col-lg-8 mx-auto">
             <textarea id="chat-log" cols="100" rows="20"></textarea>
             <input id="chat-message-input" type="text" class="py-2" size="100">
@@ -13,9 +15,19 @@
             </div>
         </div>
     </div>
+    {% else %}
+    <div id="not_allowed" class="col-md-10 col-sm-12 col-xl-10 mx-auto"></div>
+        <h1 class="text-center pt-2">Oops! Page Not Found.</h1>
+        <p class="text-center px-3">You must be logged in to access the chatrooms!</p>
+        <a href="{% url 'home' %}" class="btn btn-pink rounded mt-3 p-2"
+                aria-label="Brings you back to Home Page">Back to Home page
+        </a>
+    </div>
+    {% endif %}
 </div>
     <script>
         const roomName = JSON.parse(document.getElementById('room-name').textContent);
+        const username = JSON.parse(document.getElementById('user-username').textContent);
 
         const chatSocket = new WebSocket(
             (window.location.protocol === "https:" ? "wss://" : "ws://") +

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,7 +76,7 @@
                     {% if user.is_authenticated %}
                     <li class="nav-item px-2">
                         <a class="nav-link {% if request.path == '/chat/' %}active{% endif %}"
-                            href="{% url 'chat' %}">Sparky Chat</a>
+                            href="{% url 'chat' %}">Chat</a>
                     </li>
                     {% endif %}
                     <li class="nav-item px-2">


### PR DESCRIPTION
Unauthenticated users should now no longer be able to enter chatrooms by typing (say) /chat/casual/ on the end of the homepage url on the browser. They should receive an appropriate error page whose format is based on the existing 404 error page instead.

The format of the error pages may still need a little tweaking, but it basically works.  I'll deal with a couple of the issues in the next push.

The next step is to do the same for authorised users trying to enter chatrooms not listed on our chatroom list via the url (by typing, say, /chat/garden_shed/ on the end of the homepage url in the browser).