### PR TITLE
Jaime dev

### DIFF
--- a/chat/templates/chat/chat.html
+++ b/chat/templates/chat/chat.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block content %}
-<div class="container py-4">
+<div class="container-fluid py-4">
     <div class="row text-center py-2"">
         {% if user.is_authenticated %}
         <div class="col-md-10 col-lg-8 mx-auto">

--- a/chat/templates/chat/chatroom.html
+++ b/chat/templates/chat/chatroom.html
@@ -1,80 +1,101 @@
+
 {% extends "base.html" %}
 {% load static %}
 
 {% block content %}
-<div class="container py-4">
+<div class="container d-flex flex-column py-4">
     {% if user.is_authenticated %}
-        <div class="row">
-            <span id="user-username" style="display:none;">"{{ user.username }}"</span>
-            <h3 class="text-center px-3">Hi {{ user.username }}! You're in the <strong>{{ friendly_name }}</strong> chatroom</h3>
-            <div class="col-md-10 col-lg-8 mx-auto">
-                <div id="chat-log" class="chat-log pt-0 h-100" style="width: 100%; height: 300px; overflow-y: auto; white-space: pre-wrap;">
-                </div>
-                <input id="chat-message-input" type="text" class="py-2" size="100">
-                <div class="text-center">
-                    <input id="chat-message-submit" type="button" class="btn btn-pink mt-4" value="Send">
-                    {{ room_name|json_script:"room-name" }}
-                </div>
+    <span id="user-username" style="display:none;">"{{ user.username }}"</span>
+    <h3 class="text-center px-3">Hi {{ user.username }}! You're in the <strong>{{ friendly_name }}</strong> chatroom</h3>
+    <div class="row flex-grow-1">
+        <div class="col-md-10 col-lg-8 mx-auto d-flex flex-column h-auto">
+            <div id="chat-log" class="chat-log pt-0 h-100 flex-grow-1" style="width: 100%; max-height: 500px; min-height: 100px; overflow-y: auto; white-space: pre-wrap;">  
+            </div>
+            <input id="chat-message-input" type="text" class="py-2" size="100" style="width: 100%">
+            <div class="text-center mt-2">
+                <input id="chat-message-submit" type="button" class="btn btn-pink" value="Send">
+                {{ room_name|json_script:"room-name" }}
             </div>
         </div>
+    </div>
     {% else %}
-        <div id="not_allowed" class="col-md-10 col-sm-12 col-xl-10 mx-auto"></div>
-            <h1 class="text-center pt-2">Oops! Page Not Found.</h1>
-            <p class="text-center px-3">You must be logged in to access the chatrooms!</p>
-            <a href="{% url 'home' %}" class="btn btn-pink rounded mt-3 p-2"
-                    aria-label="Brings you back to Home Page">Back to Home page
-            </a>
-        </div>
+    <div id="not_allowed" class="col-md-10 col-sm-12 col-xl-10 mx-auto">
+        <h1 class="text-center pt-2">Oops! Page Not Found.</h1>
+        <p class="text-center px-3">You must be logged in to access the chatrooms!</p>
+        <a href="{% url 'home' %}" class="btn btn-pink rounded mt-3 p-2"
+                aria-label="Brings you back to Home Page">Back to Home page
+        </a>
+    </div>
     {% endif %}
 </div>
-    <script>
-        const roomName = JSON.parse(document.getElementById('room-name').textContent);
-        const username = JSON.parse(document.getElementById('user-username').textContent);
+<script>
+    const roomName = JSON.parse(document.getElementById('room-name').textContent);
+    const username = JSON.parse(document.getElementById('user-username').textContent);
 
-        const chatSocket = new WebSocket(
-            (window.location.protocol === "https:" ? "wss://" : "ws://") +
-            window.location.host +
-            "/ws/chat/" +
-            roomName +
-            "/"
-        );
+    const chatSocket = new WebSocket(
+        (window.location.protocol === "https:" ? "wss://" : "ws://") +
+        window.location.host +
+        "/ws/chat/" +
+        roomName +
+        "/"
+    );
 
-        chatSocket.onmessage = function(e) {
-            const data = JSON.parse(e.data);
-            const messageElement = document.createElement("div");
-            messageElement.classList.add("chat-msg");
+    let lastSender = "";
 
-            const isCurrentUser = data.message.startsWith(username + ":");
-            messageElement.classList.add(isCurrentUser ? "msg-from-user" : "msg-from-other");
+    chatSocket.onmessage = function(e) {
+        const data = JSON.parse(e.data);
+        const messageText = data.message;
 
-            messageElement.textContent = `${data.message}`;
-            document.querySelector('#chat-log').appendChild(messageElement);
-        };
+        const splitIndex = messageText.indexOf(":");
+        const sender = splitIndex !== -1 ? messageText.substring(0, splitIndex) : "";
+        const messageContent = splitIndex !== -1 ? messageText.substring(splitIndex + 1).trim() : messageText;
+        
+        const messageElement = document.createElement("div")
+        messageElement.classList.add("chat-msg");
 
-        chatSocket.onclose = function(e) {
-            console.error('Chat socket closed unexpectedly');
-        };
+        console.log("DEBUG User: ", username);
+
+        const isCurrentUser = sender === username;
+        messageElement.classList.add(isCurrentUser ? "msg-from-user" : "msg-from-other");
 
         
-        document.querySelector('#chat-message-input').focus();
-        document.querySelector('#chat-message-input').onkeyup = function(e) {
-            if (e.key === 'Enter') {
-                document.querySelector('#chat-message-submit').click();
-            }
-        };
+        if (sender !== lastSender) {
+            messageElement.textContent = `${sender}: ${messageContent}`;
+        } else {
+            messageElement.textContent = messageContent;
+        }
+
+        document.querySelector('#chat-log').appendChild(messageElement);
+
+        lastSender = sender;
+    };
+
+    chatSocket.onclose = function(e) {
+        console.error('Chat socket closed unexpectedly');
+    };
+
     
-        document.querySelector('#chat-message-submit').onclick = function(e) {
-            const messageInputDom = document.querySelector('#chat-message-input');
-            const message = messageInputDom.value;
+    document.querySelector('#chat-message-input').focus();
+    document.querySelector('#chat-message-input').onkeyup = function(e) {
+        if (e.key === 'Enter') {
+            document.querySelector('#chat-message-submit').click();
+        }
+    };
 
-        // Send the message with the username
-            chatSocket.send(JSON.stringify({
-                'message': message,
-                'username': username
-            }));
+    document.querySelector('#chat-message-submit').onclick = function(e) {
+        const messageInputDom = document.querySelector('#chat-message-input');
+        const message = messageInputDom.value;
 
-            messageInputDom.value = '';
-        };
+    // Send the message with the username
+        chatSocket.send(JSON.stringify({
+            'message': message,
+            'username': username
+        }));
 
-    </script>
+        messageInputDom.value = '';
+    };
+
+</script>
 {% endblock content %}
+
+

--- a/dating_app/settings.py
+++ b/dating_app/settings.py
@@ -37,9 +37,9 @@ TEMPLATES_DIR = os.path.join(BASE_DIR, 'templates')
 SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.herokuapp.com']
+ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.herokuapp.com', '192.168.178.48']
 
 
 # Application definition
@@ -122,12 +122,13 @@ CHANNEL_LAYERS = {
 }
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False
 
 CSRF_TRUSTED_ORIGINS = [
     'https://sparksync-test-baedaeaf485c.herokuapp.com',
     'wss://sparksync-test-baedaeaf485c.herokuapp.com',
+    'http://192.168.178.48:8000',
 ]
 
 # Database

--- a/dating_app/settings.py
+++ b/dating_app/settings.py
@@ -37,7 +37,7 @@ TEMPLATES_DIR = os.path.join(BASE_DIR, 'templates')
 SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DJANGO_DEBUG", False)
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.herokuapp.com', '192.168.178.48']
 
@@ -122,8 +122,8 @@ CHANNEL_LAYERS = {
 }
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SESSION_COOKIE_SECURE = False
-CSRF_COOKIE_SECURE = False
+SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", True)
+CSRF_COOKIE_SECURE = os.getenv("CSRF_COOKIE_SECURE", True)
 
 CSRF_TRUSTED_ORIGINS = [
     'https://sparksync-test-baedaeaf485c.herokuapp.com',

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -26,13 +26,13 @@
                 </p>
                 {% url 'account_login' as login_url %}
                 <form method="post" action="{% url 'account_login' %}" class="shadow p-3 border rounded">
-                            {% csrf_token %}
-                            {{ form|crispy }}
-                            {{ redirect_field }}
-                            <button type="submit" class="btn btn-pink mt-3" aria-label="Sign in button">
-                                {% trans "Log In" %}
-                            </button>
-                        </form>
+                    {% csrf_token %}
+                    {{ form|crispy }}
+                    {{ redirect_field }}
+                    <button type="submit" class="btn btn-pink mt-3" aria-label="Sign in button">
+                        {% trans "Log In" %}
+                    </button>
+                </form>
             {% endif %}
             {% if LOGIN_BY_CODE_ENABLED or PASSKEY_LOGIN_ENABLED %}
                 <hr class="mt-4">


### PR DESCRIPTION
I've improved the presentation and logic of the chatroom template
- by tidying up some messy bootstrap and html code
- stopping the user name from repeating on the chat log if a user sents two or more messages in succession

Because chrome and edge developer tools did not give an accurate rendering of the page using their mobile device emulators, I had to set my environment up to allow a physical mobile device to open the app in its dev version (via usb connection).

For this purpose, I needed to modify the settings file: 
SESSION_COOKIE_SECURE = True
became
SESSION_COOKIE_SECURE = os.getenv("SESSION_COOKIE_SECURE", True)
and
CSRF_COOKIE_SECURE = True
became
CSRF_COOKIE_SECURE = os.getenv("CSRF_COOKIE_SECURE", True)

This was to allow insecure connections to pass around CSRF cookies in the dev environment but prevent them from doing so in the deployed version, all without having to make multiple changes in settings before and after each commit.

While I was there, I altered the DEBUG variable logic in a similar way, also to avoid the need of making a change in the settings with every commit:

DEBUG = False
became
DEBUG = os.getenv("DJANGO_DEBUG", False)

I also had to add the following entries to my .env file:
DJANGO_DEBUG = True
SESSION_COOKIE_SECURE = False
CSRF_COOKIE_SECURE = False

I also had to list my local WLAN URL in ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS.

In the next commit I'll add some logic so that my URL is present in my .env file and is not listed in settings.py in the deployed version.



